### PR TITLE
Allow gotcha to run as a cf app

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -4,3 +4,13 @@ Custom headers are now re-instated if the backend redirects us.
 Previously, the request was retried without the custom headers,
 causing all sorts of havoc when troubleshooting services like
 Vault.
+
+## New Features
+
+`gotcha` can now run as a CF app. It honors the `PORT` env var,
+and makes use of `GOTCHA_BACKEND` and `SKIP_SSL_VERIFY` for
+configuring the backend to proxy.
+
+`gotcha` now sends HTTP requests honoring the `HTTP_PROXY`,
+`HTTPS_PROXY`, `NO_PROXY` environment variables, and their
+lower case equivalents.

--- a/main.go
+++ b/main.go
@@ -59,23 +59,25 @@ func main() {
 		return
 	}
 
-	var target *url.URL
-	var err error
+	backend := os.Getenv("GOTCHA_BACKEND")
 	args := opts.Args()
-	if len(args) == 0 {
-		target, err = url.Parse(os.Getenv("GOTCHA_BACKEND"))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to parse target '%s': %s\n", os.Getenv("GOTCHA_BACKEND"), err)
-			os.Exit(1)
-			return
-		}
-	} else {
-		target, err = url.Parse(args[0])
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to parse target '%s': %s\n", args[0], err)
-			os.Exit(1)
-			return
-		}
+	if len(args) >= 1 {
+		backend = args[0]
+	}
+
+	if backend == "" {
+		fmt.Fprintf(os.Stderr, "No backend host specified, and no $GOTCHA_BACKEND environment variable set\n\n"+
+			"If you are deploying gotcha as a Cloud Foundry application, don't forget to `cf set-env"+
+			" appname GOTCHA_BACKEND https://host/url'\n\n")
+		os.Exit(1)
+		return
+	}
+
+	target, err := url.Parse(backend)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse target '%s': %s\n", args[0], err)
+		os.Exit(1)
+		return
 	}
 	fmt.Fprintf(os.Stderr, "targeting %s\n", target)
 

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func main() {
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: *noverify,
 				},
+				Proxy: http.ProxyFromEnvironment,
 			},
 		}
 		var res *http.Response

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+name: gotcha
+env:
+  SSL_SKIP_VERIFY: false # set to true if proxying to something with self-signed certs
+# NOTE: set this environment variable to what you need in your test case, prior to `cf push`ing
+#  GOTCHA_BACKEND: http://your_backend_to_proxy:port


### PR DESCRIPTION
`gotcha` can now run as a Cloud Foundry app. It pulls
`PORT` from the environment to determine what to bind to,
and its target from the `GOTCHA_BACKEND` environment variable.

The `PORT` env var is only used if no ports are explicitly
configured via the CLI invocation of `gotcha`. If neither
CLI args nor `PORT` env var exists, fails back to port 3128.

The `GOTCHA_BACKEND` env var is only used when there are no
CLI args to gotcha at all. Otherwise, the behavior is the same
as it previously was.

Additionally, the `SSL_SKIP_VERIFY` environment variable
can be used to disable SSL certificate checking of the
backend gotcha is hooked up to.

And for kicks, the HTTP_PROXY/HTTPS_PROXY/NO_PROXY env
vars are now also supported
